### PR TITLE
Fix Organization delete when groups are configured

### DIFF
--- a/src/db/models/group.rs
+++ b/src/db/models/group.rs
@@ -151,6 +151,13 @@ impl Group {
         }
     }
 
+    pub async fn delete_all_by_organization(org_uuid: &str, conn: &mut DbConn) -> EmptyResult {
+        for group in Self::find_by_organization(org_uuid, conn).await {
+            group.delete(conn).await?;
+        }
+        Ok(())
+    }
+
     pub async fn find_by_organization(organizations_uuid: &str, conn: &mut DbConn) -> Vec<Self> {
         db_run! { conn: {
             groups::table

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -2,7 +2,7 @@ use num_traits::FromPrimitive;
 use serde_json::Value;
 use std::cmp::Ordering;
 
-use super::{CollectionUser, GroupUser, OrgPolicy, OrgPolicyType, TwoFactor, User};
+use super::{CollectionUser, Group, GroupUser, OrgPolicy, OrgPolicyType, TwoFactor, User};
 use crate::CONFIG;
 
 db_object! {
@@ -267,6 +267,7 @@ impl Organization {
         Collection::delete_all_by_organization(&self.uuid, conn).await?;
         UserOrganization::delete_all_by_organization(&self.uuid, conn).await?;
         OrgPolicy::delete_all_by_organization(&self.uuid, conn).await?;
+        Group::delete_all_by_organization(&self.uuid, conn).await?;
 
         db_run! { conn: {
             diesel::delete(organizations::table.filter(organizations::uuid.eq(self.uuid)))


### PR DESCRIPTION
With existing groups configured within an org, deleting that org would fail because of Foreign Key issues.

This PR fixes this by making sure the groups get deleted before the org does.

Fixes #3247