### PR TITLE
Validate all needed fields for client API login

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -52,6 +52,10 @@ async fn login(data: Form<ConnectData>, client_header: ClientHeaders, mut conn: 
             _check_is_some(&data.client_secret, "client_secret cannot be blank")?;
             _check_is_some(&data.scope, "scope cannot be blank")?;
 
+            _check_is_some(&data.device_identifier, "device_identifier cannot be blank")?;
+            _check_is_some(&data.device_name, "device_name cannot be blank")?;
+            _check_is_some(&data.device_type, "device_type cannot be blank")?;
+
             _api_key_login(data, &mut user_uuid, &mut conn, &ip).await
         }
         t => err!("Invalid type", t),


### PR DESCRIPTION
During the client API login we need to have a `device_identifier`, `device_name` and `device_type`. When these were not provided Vaultwarden would panic.

This PR add checks for these fields and makes sure it returns a better error message instead of causing a panic.