### PR TITLE
Fix the web-vault v2023.2.0 API calls

### DIFF
--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -627,7 +627,7 @@ async fn diagnostics(_token: AdminToken, ip_header: IpHeader, mut conn: DbConn) 
         "latest_release": latest_release,
         "latest_commit": latest_commit,
         "web_vault_enabled": &CONFIG.web_vault_enabled(),
-        "web_vault_version": web_vault_version.version,
+        "web_vault_version": web_vault_version.version.trim_start_matches('v'),
         "latest_web_build": latest_web_build,
         "running_within_docker": running_within_docker,
         "docker_base_image": if running_within_docker { docker_base_image() } else { "Not applicable" },

--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -841,6 +841,8 @@ async fn _api_key(
     headers: Headers,
     mut conn: DbConn,
 ) -> JsonResult {
+    use crate::util::format_date;
+
     let data: SecretVerificationRequest = data.into_inner().data;
     let mut user = headers.user;
 
@@ -855,6 +857,7 @@ async fn _api_key(
 
     Ok(Json(json!({
       "ApiKey": user.api_key,
+      "RevisionDate": format_date(&user.updated_at),
       "Object": "apiKey",
     })))
 }

--- a/src/api/core/emergency_access.rs
+++ b/src/api/core/emergency_access.rs
@@ -590,8 +590,16 @@ async fn view_emergency_access(emer_id: String, headers: Headers, mut conn: DbCo
 
     let mut ciphers_json = Vec::with_capacity(ciphers.len());
     for c in ciphers {
-        ciphers_json
-            .push(c.to_json(&headers.host, &emergency_access.grantor_uuid, Some(&cipher_sync_data), &mut conn).await);
+        ciphers_json.push(
+            c.to_json(
+                &headers.host,
+                &emergency_access.grantor_uuid,
+                Some(&cipher_sync_data),
+                CipherSyncType::User,
+                &mut conn,
+            )
+            .await,
+        );
     }
 
     Ok(Json(json!({

--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -237,6 +237,7 @@ fn config() -> Json<Value> {
           "notifications": format!("{domain}/notifications"),
           "sso": "",
         },
+        "object": "config",
     }))
 }
 

--- a/src/db/models/group.rs
+++ b/src/db/models/group.rs
@@ -64,7 +64,32 @@ impl Group {
             "AccessAll": self.access_all,
             "ExternalId": self.external_id,
             "CreationDate": format_date(&self.creation_date),
-            "RevisionDate": format_date(&self.revision_date)
+            "RevisionDate": format_date(&self.revision_date),
+            "Object": "group"
+        })
+    }
+
+    pub async fn to_json_details(&self, conn: &mut DbConn) -> Value {
+        let collections_groups: Vec<Value> = CollectionGroup::find_by_group(&self.uuid, conn)
+            .await
+            .iter()
+            .map(|entry| {
+                json!({
+                    "Id": entry.collections_uuid,
+                    "ReadOnly": entry.read_only,
+                    "HidePasswords": entry.hide_passwords
+                })
+            })
+            .collect();
+
+        json!({
+            "Id": self.uuid,
+            "OrganizationId": self.organizations_uuid,
+            "Name": self.name,
+            "AccessAll": self.access_all,
+            "ExternalId": self.external_id,
+            "Collections": collections_groups,
+            "Object": "groupDetails"
         })
     }
 

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -326,7 +326,7 @@ impl UserOrganization {
             // TODO: Add support for Custom User Roles
             // See: https://bitwarden.com/help/article/user-types-access-control/#custom-role
             // "Permissions": {
-            //     "AccessEventLogs": false, // Not supported
+            //     "AccessEventLogs": false,
             //     "AccessImportExport": false,
             //     "AccessReports": false,
             //     "ManageAllCollections": false,
@@ -337,9 +337,9 @@ impl UserOrganization {
             //     "editAssignedCollections": false,
             //     "deleteAssignedCollections": false,
             //     "ManageCiphers": false,
-            //     "ManageGroups": false, // Not supported
+            //     "ManageGroups": false,
             //     "ManagePolicies": false,
-            //     "ManageResetPassword": false, // Not supported
+            //     "ManageResetPassword": false,
             //     "ManageSso": false, // Not supported
             //     "ManageUsers": false,
             //     "ManageScim": false, // Not supported (Not AGPLv3 Licensed)
@@ -358,7 +358,12 @@ impl UserOrganization {
         })
     }
 
-    pub async fn to_json_user_details(&self, conn: &mut DbConn) -> Value {
+    pub async fn to_json_user_details(
+        &self,
+        include_collections: bool,
+        include_groups: bool,
+        conn: &mut DbConn,
+    ) -> Value {
         let user = User::find_by_uuid(&self.user_uuid, conn).await.unwrap();
 
         // Because BitWarden want the status to be -1 for revoked users we need to catch that here.
@@ -371,11 +376,37 @@ impl UserOrganization {
 
         let twofactor_enabled = !TwoFactor::find_by_user(&user.uuid, conn).await.is_empty();
 
+        let groups: Vec<String> = if include_groups && CONFIG.org_groups_enabled() {
+            GroupUser::find_by_user(&self.uuid, conn).await.iter().map(|gu| gu.groups_uuid.clone()).collect()
+        } else {
+            // The Bitwarden clients seem to call this API regardless of whether groups are enabled,
+            // so just act as if there are no groups.
+            Vec::with_capacity(0)
+        };
+
+        let collections: Vec<Value> = if include_collections {
+            CollectionUser::find_by_organization_and_user_uuid(&self.org_uuid, &self.user_uuid, conn)
+                .await
+                .iter()
+                .map(|cu| {
+                    json!({
+                        "Id": cu.collection_uuid,
+                        "ReadOnly": cu.read_only,
+                        "HidePasswords": cu.hide_passwords,
+                    })
+                })
+                .collect()
+        } else {
+            Vec::with_capacity(0)
+        };
+
         json!({
             "Id": self.uuid,
             "UserId": self.user_uuid,
             "Name": user.name,
             "Email": user.email,
+            "Groups": groups,
+            "Collections": collections,
 
             "Status": status,
             "Type": self.atype,


### PR DESCRIPTION
- Supports the new Collection/Group/User editing UI's
- Support `/partial` endpoint for cipher updating to allow folder and favorite update for read-only ciphers.
- Prevent `Favorite`, `Folder`, `read-only` and `hide-passwords` from being added to the organizational sync.
- Added and corrected some `Object` key's to the output json.
